### PR TITLE
LINUX; RHEL, Fedora, and CentOS based distributions [{PULL RQ}]

### DIFF
--- a/LINUX; RHEL, Fedora, and CentOS based distributions
+++ b/LINUX; RHEL, Fedora, and CentOS based distributions
@@ -1,0 +1,2 @@
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.repos.d/vscode.repo > /dev/null


### PR DESCRIPTION
We currently ship the stable 64-bit VS Code for RHEL, Fedora, or CentOS based distributions in a yum repository. 
Update package cache and install the package using [dnf] (fedora 22 and above):  
-=-=-=-=-
dnf check-update
sudo dnf install code # or code-insiders
-=-=-=-=-
or an older versions using [yum]:
-=-=-=-=-
yum check-update
sudo yum install code # or code-insiders
-=-=-=-=-
----!!----
Note::
Due to the manual signing process and the publishing system we use, the yum repo could lag behind and might not immediately get the latest version of VS Code.
 ----!!----
![Screenshot 2025-02-06 10 11 59]
(https://github.com/user-attachments/assets/234c9c14-2172-469f-b6c5-83ae6967ed0d)
